### PR TITLE
Do stddev online, avoid dependency

### DIFF
--- a/lib/ping-promise.js
+++ b/lib/ping-promise.js
@@ -17,7 +17,6 @@ var os = require('os');
 
 // 3rd-party library
 var Q = require('q');
-var stdev = require('stdev');
 
 // Our library
 var linuxBuilder = require('./builder/linux');
@@ -75,7 +74,6 @@ function probe(addr, config) {
 
     ls.on('close', function (code) {
         var result;
-        var time;
         var lines = outstring.split('\n');
         // workaround for windows machines
         // if host is unreachable ping will return
@@ -105,37 +103,42 @@ function probe(addr, config) {
             result = code === 0;
         }
 
-        var times = [];
-        var setFirstTime = false;
-
+        var time = null;
+        var min = null;
+        var max = null;
+        var N = 0;
+        var sum = 0;
+        var sumsq = 0;
         for (var t = 0; t < lines.length; t++) {
             var match = /time=([0-9\.]+)\s*ms/i.exec(lines[t]);
             if (match) {
-                var tempTime = parseFloat(match[1], 10);
-                if (!setFirstTime) {
-                    time = tempTime;
-                    setFirstTime = true;
+                var parsedTime = parseFloat(match[1], 10);
+                if (time === null) {
+                    time = parsedTime;
                 }
-                times.push(tempTime);
+                if (min === null || min > parsedTime) {
+                    min = parsedTime;
+                }
+                if (max === null || max < parsedTime) {
+                    max = parsedTime;
+                }
+                N += 1;
+                sum += parsedTime
+                sumsq += parsedTime*parsedTime
             }
         }
-
-        //calculate average
-        var sum = 0;
-        for (var i=0; i<times.length; i++) 
-            sum += times[i];
-        var avg = (sum / times.length);        
-
+        var avg = sum / N
+        var stddev = Math.sqrt((sumsq/N)-(avg * avg))
         //set times
         var result = {
             host: addr,
             alive: result,
             output: outstring,
             time: time,
-            min: Math.min.apply( Math, times ),
-            max: Math.max.apply( Math, times ),
+            min: min,
+            max: max,
             avg: avg,            
-            stddev: stdev(times)
+            stddev: stddev
         };  
 
         deferred.resolve(result);

--- a/package.json
+++ b/package.json
@@ -28,8 +28,7 @@
     "node": ">=0.6.2"
   },
   "dependencies": {
-    "q": "1.x",
-    "stdev": "0.0.1"
+    "q": "1.x"
   },
   "devDependencies": {},
   "main": "index.js"


### PR DESCRIPTION
May I suggest this as an update? Stddev is pretty straightforward to calculate directly with little risk, I think it's worth avoiding this as a new dependency.
